### PR TITLE
fix(typo): "Typescript" --> "TypeScript"

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -41,7 +41,7 @@ export default defineConfig({
 						link: '/docs/guide/options',
 					},
 					{
-						text: 'Typescript Declarations',
+						text: 'TypeScript Declarations',
 						link: '/docs/guide/typescript-declarations',
 					},
 					{ text: 'Workspaces', link: '/docs/guide/workspaces' },

--- a/src/cli/new.ts
+++ b/src/cli/new.ts
@@ -36,7 +36,7 @@ const TEMPLATES: Template[] = [
 	{
 		type: 'typescript',
 		defaultName: 'my-ts-lib',
-		name: 'Typescript Library',
+		name: 'TypeScript Library',
 		dir: 'ts-lib',
 		monorepoDir: 'ts-lib-monorepo',
 	},


### PR DESCRIPTION
### Description

Capitalizes "TypeScript" in user-facing docs.
<!-- Describe your changes in detail -->

### Related Issue
<!-- If this PR is related to an issue, please link it here -->

This PR closes #<issue_number>
